### PR TITLE
Add missing nodes and marks

### DIFF
--- a/lib/tip_tap.rb
+++ b/lib/tip_tap.rb
@@ -15,6 +15,7 @@ require "tip_tap/nodes/task_list"
 require "tip_tap/nodes/text"
 require "tip_tap/nodes/image"
 require "tip_tap/nodes/blockquote"
+require "tip_tap/nodes/codeblock"
 
 module TipTap
   class Error < StandardError; end

--- a/lib/tip_tap.rb
+++ b/lib/tip_tap.rb
@@ -14,6 +14,7 @@ require "tip_tap/nodes/task_item"
 require "tip_tap/nodes/task_list"
 require "tip_tap/nodes/text"
 require "tip_tap/nodes/image"
+require "tip_tap/nodes/blockquote"
 
 module TipTap
   class Error < StandardError; end

--- a/lib/tip_tap/document.rb
+++ b/lib/tip_tap/document.rb
@@ -43,5 +43,12 @@ module TipTap
     def image(src:)
       add_content(Nodes::Image.new(src: src))
     end
+
+    def blockquote(&block)
+      raise ArgumentError, "Block required" if block.nil?
+
+      add_content(Nodes::Blockquote.new(&block))
+    end
+
   end
 end

--- a/lib/tip_tap/document.rb
+++ b/lib/tip_tap/document.rb
@@ -50,5 +50,10 @@ module TipTap
       add_content(Nodes::Blockquote.new(&block))
     end
 
+    def codeblock(&block)
+      raise ArgumentError, "Block required" if block.nil?
+
+      add_content(Nodes::Codeblock.new(&block))
+    end
   end
 end

--- a/lib/tip_tap/nodes/blockquote.rb
+++ b/lib/tip_tap/nodes/blockquote.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "tip_tap/node"
+
+module TipTap
+  module Nodes
+    class Blockquote < Node
+      self.type_name = "blockquote"
+      self.html_tag = :blockquote
+      self.html_class_name = "blockquote"
+
+      def paragraph(&block)
+        raise ArgumentError, "Block required" if block.nil?
+
+        add_content(Paragraph.new(&block))
+      end
+    end
+  end
+end

--- a/lib/tip_tap/nodes/codeblock.rb
+++ b/lib/tip_tap/nodes/codeblock.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "tip_tap/node"
+
+module TipTap
+  module Nodes
+    class Codeblock < Node
+      self.type_name = "codeBlock"
+      self.html_tag = :pre
+
+      def code(text)
+        add_content(Text.new(text, marks: [{type: "code"}]))
+      end
+    end
+  end
+end

--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -36,6 +36,7 @@ module TipTap
         value = content_tag(:strong, value) if bold?
         value = content_tag(:s, value) if strike?
         value = content_tag(:a, value, href: link_href, target: link_target) if link?
+        value = content_tag(:span, value, style: inline_style_content(text_styles)) if text_style?
         value
       end
 
@@ -67,6 +68,10 @@ module TipTap
         has_mark_with_type?("code")
       end
 
+      def text_style?
+        has_mark_with_type?("textStyle")
+      end
+
       def link_href
         marks.find { |mark| mark["type"] == "link" }&.dig("attrs", "href")
       end
@@ -75,10 +80,18 @@ module TipTap
         marks.find { |mark| mark["type"] == "link" }&.dig("attrs", "target")
       end
 
+      def text_styles
+        marks.find { |mark| mark["type"] == "textStyle" }&.dig("attrs")
+      end
+
       private
 
       def has_mark_with_type?(type)
         marks.any? { |mark| mark["type"] == type }
+      end
+
+      def inline_style_content(styles)
+        styles.reduce("") { |acc, val| acc + "#{val[0]}:#{val[1]};" }
       end
     end
   end

--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -30,6 +30,7 @@ module TipTap
 
       def to_html
         value = text
+        value = content_tag(:code, value) if code?
         value = content_tag(:u, value) if underline?
         value = content_tag(:em, value) if italic?
         value = content_tag(:strong, value) if bold?
@@ -55,6 +56,10 @@ module TipTap
 
       def link?
         has_mark_with_type?("link")
+      end
+
+      def code?
+        has_mark_with_type?("code")
       end
 
       def link_href

--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -34,6 +34,7 @@ module TipTap
         value = content_tag(:u, value) if underline?
         value = content_tag(:em, value) if italic?
         value = content_tag(:strong, value) if bold?
+        value = content_tag(:s, value) if strike?
         value = content_tag(:a, value, href: link_href, target: link_target) if link?
         value
       end
@@ -56,6 +57,10 @@ module TipTap
 
       def link?
         has_mark_with_type?("link")
+      end
+
+      def strike?
+        has_mark_with_type?("strike")
       end
 
       def code?

--- a/spec/tip_tap/document_spec.rb
+++ b/spec/tip_tap/document_spec.rb
@@ -181,4 +181,18 @@ RSpec.describe TipTap::Document do
       expect(document.content.first).to be_a(TipTap::Nodes::BulletList)
     end
   end
+
+  describe "blockquote" do
+    it "adds a blockquote node" do
+      document = TipTap::Document.new do |document|
+        document.blockquote do |quote|
+          quote.paragraph do |para|
+            para.text("Hello World!")
+          end
+        end
+      end
+
+      expect(document.content.first).to be_a(TipTap::Nodes::Blockquote)
+    end
+  end
 end

--- a/spec/tip_tap/document_spec.rb
+++ b/spec/tip_tap/document_spec.rb
@@ -195,4 +195,16 @@ RSpec.describe TipTap::Document do
       expect(document.content.first).to be_a(TipTap::Nodes::Blockquote)
     end
   end
+
+  describe "codeblock" do
+    it "adds a codeblock node" do
+      document = TipTap::Document.new do |document|
+        document.codeblock do |codeblock|
+          codeblock.code("Hello World!")
+        end
+      end
+
+      expect(document.content.first).to be_a(TipTap::Nodes::Codeblock)
+    end
+  end
 end

--- a/spec/tip_tap/nodes/blockquote_spec.rb
+++ b/spec/tip_tap/nodes/blockquote_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "tip_tap"
+
+RSpec.describe TipTap::Nodes::Blockquote do
+  let(:json_content) do
+    {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {type: "text", text: "Hello World!"}
+          ]
+        }
+      ]
+    }
+  end
+  describe "to_html" do
+    it "returns a blockquote tag" do
+      node = TipTap::Nodes::Blockquote.from_json(json_content)
+      html = node.to_html
+
+      expect(html).to eq('<blockquote class="blockquote"><p>Hello World!</p></blockquote>')
+    end
+  end
+
+  describe "to_json" do
+    it "returns a JSON object" do
+      node = TipTap::Nodes::Blockquote.from_json(json_content)
+      json = node.to_json
+
+      expect(json).to eq(json_content.merge(type: "blockquote").deep_symbolize_keys)
+    end
+  end
+
+  describe "paragraph" do
+    it "adds a paragraph to the list item" do
+      node = TipTap::Nodes::Blockquote.new
+      node.paragraph do |p|
+        p.text("Hello World!")
+      end
+
+      expect(node.content.first).to be_a(TipTap::Nodes::Paragraph)
+    end
+  end
+end

--- a/spec/tip_tap/nodes/codeblock_spec.rb
+++ b/spec/tip_tap/nodes/codeblock_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "tip_tap"
+
+RSpec.describe TipTap::Nodes::Codeblock do
+  describe "to_html" do
+    it "returns a pre tag" do
+      node = TipTap::Nodes::Codeblock.from_json({content: []})
+      html = node.to_html
+
+      expect(html).to eq("<pre></pre>")
+    end
+  end
+
+  describe "to_json" do
+    it "returns a JSON object" do
+      node = TipTap::Nodes::Codeblock.new
+      json = node.to_json
+
+      expect(json).to eq({type: "codeBlock", content: []})
+    end
+  end
+
+  describe "code" do
+    it "adds a text node to the node with a code mark" do
+      paragraph = TipTap::Nodes::Codeblock.new
+      paragraph.code("Hello World!")
+
+      text = paragraph.content.first
+      expect(text).to be_a(TipTap::Nodes::Text)
+      expect(text.code?).to eq(true)
+    end
+  end
+end

--- a/spec/tip_tap/nodes/text_spec.rb
+++ b/spec/tip_tap/nodes/text_spec.rb
@@ -85,6 +85,15 @@ RSpec.describe TipTap::Nodes::Text do
           expect(html).to eq('<a href="https://example.com" target="_blank">Hello World!</a>')
         end
       end
+
+      context "text style" do
+        it "returns the text wrapped in a span tag" do
+          node = TipTap::Nodes::Text.from_json({text: "Hello World!", marks: [{type: "textStyle", attrs: {color: "#f0f0f0"}}]})
+          html = node.to_html
+
+          expect(html).to eq('<span style="color:#f0f0f0;">Hello World!</span>')
+        end
+      end
     end
   end
 

--- a/spec/tip_tap/nodes/text_spec.rb
+++ b/spec/tip_tap/nodes/text_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe TipTap::Nodes::Text do
         end
       end
 
+      context "strikethrough" do
+        it "returns the text wrapped in a s tag" do
+          node = TipTap::Nodes::Text.from_json({text: "Hello World!", marks: [{type: "strike"}]})
+          html = node.to_html
+
+          expect(html).to eq("<s>Hello World!</s>")
+        end
+      end
+
       context "code" do
         it "returns the text wrapped in a code tag" do
           node = TipTap::Nodes::Text.from_json({text: "Hello World!", marks: [{type: "code"}]})

--- a/spec/tip_tap/nodes/text_spec.rb
+++ b/spec/tip_tap/nodes/text_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe TipTap::Nodes::Text do
         end
       end
 
+      context "code" do
+        it "returns the text wrapped in a code tag" do
+          node = TipTap::Nodes::Text.from_json({text: "Hello World!", marks: [{type: "code"}]})
+          html = node.to_html
+
+          expect(html).to eq("<code>Hello World!</code>")
+        end
+      end
+
       context "bold, italic, and underline" do
         it "returns the text wrapped in a strong, em, and u tags" do
           node = TipTap::Nodes::Text.from_json({text: "Hello World!", marks: [{type: "italic"}, {type: "bold"}, {type: "underline"}]})


### PR DESCRIPTION
This PR checks off a few items in #1 and #2. Namely it adds `blockquote` and `codeblock` nodes as well as `strike`, `code`, and `textStyle` marks.