### PR TITLE
Extract Registration to Module

### DIFF
--- a/lib/tip_tap/document.rb
+++ b/lib/tip_tap/document.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "tip_tap/registerable"
 require "tip_tap/node"
 
 # This is the class that all child nodes will be added to.

--- a/lib/tip_tap/document.rb
+++ b/lib/tip_tap/document.rb
@@ -1,19 +1,12 @@
 # frozen_string_literal: true
 
-require "tip_tap/html_renderable"
-require "tip_tap/json_renderable"
-require "tip_tap/plain_text_renderable"
-require "tip_tap/has_content"
+require "tip_tap/registerable"
+require "tip_tap/node"
 
 # This is the class that all child nodes will be added to.
 # This is the root object for TipTap.
 module TipTap
-  class Document
-    include JsonRenderable
-    include HtmlRenderable
-    include PlainTextRenderable
-    include HasContent
-
+  class Document < Node
     self.type_name = "doc"
     self.html_tag = :div
     self.html_class_name = "tiptap-document"

--- a/lib/tip_tap/json_renderable.rb
+++ b/lib/tip_tap/json_renderable.rb
@@ -4,25 +4,6 @@ require "tip_tap/registry"
 
 module TipTap
   module JsonRenderable
-    def self.included(base)
-      base.extend(ClassMethods)
-    end
-
-    module ClassMethods
-      def type_name=(type_name)
-        @type_name = type_name
-        Registry.register(type_name, self)
-      end
-
-      def type_name
-        @type_name
-      end
-    end
-
-    def type_name
-      self.class.type_name
-    end
-
     def include_empty_content_in_json?
       true
     end

--- a/lib/tip_tap/node.rb
+++ b/lib/tip_tap/node.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "tip_tap/registerable"
 require "tip_tap/html_renderable"
 require "tip_tap/json_renderable"
 require "tip_tap/plain_text_renderable"
@@ -10,6 +11,7 @@ require "tip_tap/has_content"
 # converting to HTML, JSON, and plain text
 module TipTap
   class Node
+    include Registerable
     include HtmlRenderable
     include JsonRenderable
     include PlainTextRenderable

--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require "tip_tap/registerable"
 require "tip_tap/json_renderable"
 require "tip_tap/html_renderable"
 
 module TipTap
   module Nodes
     class Text
+      include Registerable
       include JsonRenderable
       include HtmlRenderable
 

--- a/lib/tip_tap/registerable.rb
+++ b/lib/tip_tap/registerable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "tip_tap/registry"
+
+module TipTap
+  module Registerable
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def type_name=(type_name)
+        @type_name = type_name
+        Registry.register(type_name, self)
+      end
+
+      def type_name
+        @type_name
+      end
+    end
+
+    def type_name
+      self.class.type_name
+    end
+  end
+end


### PR DESCRIPTION
Instead of having `JsonRenderable` store the `type_name` and register the Node I think it makes more sense to extract that to a module and include that in the `Node` and `Text` components. I also made `Document` a sublcass of `Node` since it was just repeating everything `Node` was doing.