### PR TITLE
Implement enumerable for has_content module

### DIFF
--- a/lib/tip_tap/has_content.rb
+++ b/lib/tip_tap/has_content.rb
@@ -4,6 +4,8 @@ require "active_support/core_ext/hash"
 
 module TipTap
   module HasContent
+    include Enumerable
+
     attr_reader :attrs, :content
 
     def self.included(base)
@@ -20,12 +22,22 @@ module TipTap
       yield self if block_given?
     end
 
-    def find_node(node_type)
-      content.find { |child| child.is_a?(node_type) }
+    def each
+      content.each { |child| yield child }
+    end
+
+    def find_node(type_class_or_name)
+      node_type = type_class_or_name.is_a?(String) ? TipTap.node_for(type_class_or_name) : type_class_or_name
+      find { |child| child.is_a?(node_type) }
     end
 
     def add_content(node)
       @content << node
+    end
+    alias_method :<<, :add_content
+
+    def size
+      content.size
     end
 
     module ClassMethods

--- a/spec/tip_tap/document_spec.rb
+++ b/spec/tip_tap/document_spec.rb
@@ -80,13 +80,50 @@ RSpec.describe TipTap::Document do
     end
   end
 
-  describe "find_node" do
-    it "returns a node" do
-      document = TipTap::Document.from_json(json_contents)
-      node = document.find_node(TipTap::Nodes::Paragraph)
+  describe "Enumerable" do
+    it "iterates over the content for #each" do
+      json = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "Hello World!",
+                marks: [
+                  {type: "bold"},
+                  {type: "italic"}
+                ]
+              }
+            ]
+          }
+        ]
+      }
+      document = TipTap::Document.from_json(json)
+      expect(document.map(&:class)).to eq([TipTap::Nodes::Paragraph])
+    end
+  end
 
-      expect(node).to be_a(TipTap::Nodes::Paragraph)
-      expect(node.to_plain_text).to eq("Hello World!")
+  describe "find_node" do
+    context "when passing a string" do
+      it "returns a node" do
+        document = TipTap::Document.from_json(json_contents)
+        node = document.find_node(TipTap::Nodes::Paragraph.type_name)
+
+        expect(node).to be_a(TipTap::Nodes::Paragraph)
+        expect(node.to_plain_text).to eq("Hello World!")
+      end
+    end
+
+    context "when passing a class" do
+      it "returns a node" do
+        document = TipTap::Document.from_json(json_contents)
+        node = document.find_node(TipTap::Nodes::Paragraph)
+
+        expect(node).to be_a(TipTap::Nodes::Paragraph)
+        expect(node.to_plain_text).to eq("Hello World!")
+      end
     end
   end
 


### PR DESCRIPTION
There are cases I am hitting where I need to use some enumerable methods while interacting with a `HasContent` class. In this case rather than implementing a bunch of custom methods I decided to `include Enumerable` and implement `each`, `<<` and `size`. I think that should solve most of the use cases I am finding.

While I was in there I also refactored `find_node` to use `Enumerable#find` and allow a type name or class.