### PR TITLE
Allow customizing the separator when rendering to plain text

### DIFF
--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -37,7 +37,7 @@ module TipTap
         value
       end
 
-      def to_plain_text
+      def to_plain_text(separator: " ")
         text
       end
 

--- a/lib/tip_tap/plain_text_renderable.rb
+++ b/lib/tip_tap/plain_text_renderable.rb
@@ -4,7 +4,7 @@ module TipTap
   module PlainTextRenderable
     # Useful for searching
     def to_plain_text(separator: " ")
-      content.map(&:to_plain_text).join(separator)
+      content.map { |node| node.to_plain_text(separator: separator) }.join(separator)
     end
   end
 end

--- a/lib/tip_tap/plain_text_renderable.rb
+++ b/lib/tip_tap/plain_text_renderable.rb
@@ -3,8 +3,8 @@
 module TipTap
   module PlainTextRenderable
     # Useful for searching
-    def to_plain_text
-      content.map(&:to_plain_text).join(" ")
+    def to_plain_text(separator: " ")
+      content.map(&:to_plain_text).join(separator)
     end
   end
 end


### PR DESCRIPTION
You may want plain text to be separated by something other than a space, such as a newline. This PR allows you to specify a separator to use when joining the plain text content.