### PR TITLE
Convert to_json to as_json to follow Ruby/Rails convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A gem for parsing, generating, and rendering TipTap Documents and Nodes using Ruby.
 
+## Note
+
+This gem is under active development and is changing somewhat quickly. There is a chance that there may be breaking changes until a stable version is released.
+
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:
@@ -55,7 +59,7 @@ Once you have a Document with some content you can render it to HTML, JSON, and 
 #### JSON
 
 ```ruby
-document.to_json # => { type: 'doc', content: […nodes]}
+document.as_json # => { type: 'doc', content: […nodes]}
 ```
 
 ### HTML

--- a/lib/tip_tap/json_renderable.rb
+++ b/lib/tip_tap/json_renderable.rb
@@ -9,12 +9,13 @@ module TipTap
     end
 
     # Generate a JSON object that is useable by the editor
-    def to_json
+    def as_json
       json = {type: type_name}
-      json = json.merge(content: content.map(&:to_json)) if should_include_content?
+      json = json.merge(content: content.map(&:as_json)) if should_include_content?
       json = json.merge(attrs: attrs.deep_symbolize_keys) if attrs.present?
       json
     end
+    alias_method :to_h, :as_json
 
     private
 

--- a/lib/tip_tap/nodes/text.rb
+++ b/lib/tip_tap/nodes/text.rb
@@ -21,7 +21,7 @@ module TipTap
         new(json["text"], marks: Array(json["marks"]))
       end
 
-      def to_json
+      def as_json
         {type: type_name, text: text, marks: marks.map(&:deep_symbolize_keys)}.compact_blank
       end
 

--- a/spec/tip_tap/document_spec.rb
+++ b/spec/tip_tap/document_spec.rb
@@ -145,10 +145,10 @@ RSpec.describe TipTap::Document do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON string" do
       document = TipTap::Document.from_json(json_contents)
-      json = document.to_json
+      json = document.as_json
 
       expect(json).to eq({
         type: "doc",

--- a/spec/tip_tap/node_spec.rb
+++ b/spec/tip_tap/node_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe TipTap::Node do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     context "when the node is a Node class" do
       it "returns an only the content" do
         node = TipTap::Node.new
-        expect(node.to_json).to eq({type: nil, content: []})
+        expect(node.as_json).to eq({type: nil, content: []})
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe TipTap::Node do
         klass = Class.new(TipTap::Node)
         klass.type_name = "myTestNode"
         node = klass.new(test: "test")
-        expect(node.to_json).to eq({type: "myTestNode", content: [], attrs: {test: "test"}})
+        expect(node.as_json).to eq({type: "myTestNode", content: [], attrs: {test: "test"}})
       end
     end
   end

--- a/spec/tip_tap/nodes/blockquote_spec.rb
+++ b/spec/tip_tap/nodes/blockquote_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe TipTap::Nodes::Blockquote do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::Blockquote.from_json(json_content)
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq(json_content.merge(type: "blockquote").deep_symbolize_keys)
     end

--- a/spec/tip_tap/nodes/bullet_list_spec.rb
+++ b/spec/tip_tap/nodes/bullet_list_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe TipTap::Nodes::BulletList do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::BulletList.from_json(json_contents)
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq(json_contents.merge(type: "bulletList").deep_symbolize_keys)
     end

--- a/spec/tip_tap/nodes/codeblock_spec.rb
+++ b/spec/tip_tap/nodes/codeblock_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe TipTap::Nodes::Codeblock do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::Codeblock.new
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq({type: "codeBlock", content: []})
     end

--- a/spec/tip_tap/nodes/hard_break_spec.rb
+++ b/spec/tip_tap/nodes/hard_break_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe TipTap::Nodes::HardBreak do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::HardBreak.new
-      expect(node.to_json).to eq({type: "hardBreak"})
+      expect(node.as_json).to eq({type: "hardBreak"})
     end
   end
 end

--- a/spec/tip_tap/nodes/heading_spec.rb
+++ b/spec/tip_tap/nodes/heading_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe TipTap::Nodes::Heading do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::Heading.new(level: 1)
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq({type: "heading", attrs: {level: 1}, content: []})
     end

--- a/spec/tip_tap/nodes/horizontal_rule_spec.rb
+++ b/spec/tip_tap/nodes/horizontal_rule_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe TipTap::Nodes::HorizontalRule do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::HorizontalRule.new
-      expect(node.to_json).to eq({type: "horizontalRule"})
+      expect(node.as_json).to eq({type: "horizontalRule"})
     end
   end
 end

--- a/spec/tip_tap/nodes/image_spec.rb
+++ b/spec/tip_tap/nodes/image_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe TipTap::Nodes::Image do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::Image.new(src: "https://img.companycam.com/abcd1234.jpeg")
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq({type: "image", attrs: {src: "https://img.companycam.com/abcd1234.jpeg"}})
     end

--- a/spec/tip_tap/nodes/list_item_spec.rb
+++ b/spec/tip_tap/nodes/list_item_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe TipTap::Nodes::ListItem do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::ListItem.from_json(json_content)
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq(json_content.merge(type: "listItem").deep_symbolize_keys)
     end

--- a/spec/tip_tap/nodes/ordered_list_spec.rb
+++ b/spec/tip_tap/nodes/ordered_list_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe TipTap::Nodes::OrderedList do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::OrderedList.from_json(json_contents)
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq(json_contents.merge(type: "orderedList").deep_symbolize_keys)
     end

--- a/spec/tip_tap/nodes/paragraph_spec.rb
+++ b/spec/tip_tap/nodes/paragraph_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe TipTap::Nodes::Paragraph do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::Paragraph.new
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq({type: "paragraph", content: []})
     end

--- a/spec/tip_tap/nodes/task_item_spec.rb
+++ b/spec/tip_tap/nodes/task_item_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe TipTap::Nodes::TaskItem do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::TaskItem.new(checked: true)
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq({type: "taskItem", attrs: {checked: true}, content: []})
     end

--- a/spec/tip_tap/nodes/task_list_spec.rb
+++ b/spec/tip_tap/nodes/task_list_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe TipTap::Nodes::TaskList do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::TaskList.new
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq({type: "taskList", content: []})
     end

--- a/spec/tip_tap/nodes/text_spec.rb
+++ b/spec/tip_tap/nodes/text_spec.rb
@@ -97,10 +97,10 @@ RSpec.describe TipTap::Nodes::Text do
     end
   end
 
-  describe "to_json" do
+  describe "as_json" do
     it "returns a JSON object" do
       node = TipTap::Nodes::Text.new("Hello World!", marks: [{type: "bold"}, {type: "italic"}])
-      json = node.to_json
+      json = node.as_json
 
       expect(json).to eq({type: "text", text: "Hello World!", marks: [{type: "bold"}, {type: "italic"}]})
     end

--- a/spec/tip_tap_spec.rb
+++ b/spec/tip_tap_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe TipTap do
     end
 
     it "parses the json and serializes it back to json" do
-      document_2 = TipTap::Document.from_json(document.to_json)
-      expect(document.to_json).to eq(document_2.to_json)
+      document_2 = TipTap::Document.from_json(document.as_json)
+      expect(document.as_json).to eq(document_2.as_json)
     end
   end
 end


### PR DESCRIPTION
Presently we are using `to_json` to render the `JsonRenderable` class to a Hash representation of the object (useful for storing in the DB for example). That doesn't follow the convention though where `to_json` should return the JSON string representation of the object. Instead we should be using `as_json` or `to_h`. I opted to implement `as_json` and alias `to_h` to that method.